### PR TITLE
(mostly) fix installing 1Password into /usr/lib

### DIFF
--- a/scripts/1password.sh
+++ b/scripts/1password.sh
@@ -4,35 +4,59 @@ set -e
 
 echo "Installing 1Password"
 
-cd "$(mktemp -d)"
+mkdir /var/opt # temporary storage, will not end up in ostree
+rpm-ostree install https://downloads.1password.com/linux/rpm/stable/x86_64/1password-latest.rpm
 
-wget -q https://downloads.1password.com/linux/rpm/stable/x86_64/1password-latest.rpm
+mv /var/opt/1Password /usr/lib/1Password # move installed 1password to non-volatile /usr/lib
 
-mkdir /var/opt
-rpm -ivh ./1password-latest.rpm
-
-# This is where the mess starts. 1Password is installed to /opt/1Password with
-# No way to change it. RIP. So we kinda _hack_ it and hope nothing is hard set
-# in the compiled code :(
-mv /var/opt/1Password /usr/lib/1Password
-
-# Rewrite some hard set paths here
-grep -rl "/opt/1Password" /usr/lib/1Password | xargs sed -i 's/\/opt\/1Password/\/usr\/lib\/1Password/g'
-grep -rl "/opt/1Password" /usr/share/applications | xargs sed -i 's/\/opt\/1Password/\/usr\/lib\/1Password/g'
-
-# And redo the binary link
+#create symlink /usr/bin/1password pointing to /opt/1Password/1password
 rm /usr/bin/1password
-ln -s /usr/lib/1Password/1password /usr/bin/1password
+ln -s /opt/1Password/1password /usr/bin/1password
+
+# hacked from 1password-latest.tar.gz//after-install.sh
+
+cd /usr/lib/1Password
+# chrome-sandbox requires the setuid bit to be specifically set.
+# See https://github.com/electron/electron/issues/17972
+chmod 4755 /usr/lib/1Password/chrome-sandbox
+
+GROUP_NAME="onepassword"
+GID_OP="1500"
+GID_OPCLI="1600"
+
+# Setup the Core App Integration helper binary with the correct permissions and group
+# if [ ! "$(getent group "${GROUP_NAME}")" ]; then
+#   # GID must be > 1000, and I'd prefer GID > highest user GID
+#   groupadd -K GID_MIN=1500 "${GROUP_NAME}"
+# fi
+
+HELPER_PATH="/usr/lib/1Password/1Password-KeyringHelper"
+BROWSER_SUPPORT_PATH="/usr/lib/1Password/1Password-BrowserSupport"
+
+chgrp -R "${GID_OP}" /usr/lib/1Password
+# The binary requires setuid so it may interact with the Kernel keyring facilities
+chmod u+s $HELPER_PATH
+chmod g+s $HELPER_PATH
+
+# This gives no extra permissions to the binary. It only hardens it against environmental tampering.
+chgrp "${GID_OP}" $BROWSER_SUPPORT_PATH
+chmod g+s $BROWSER_SUPPORT_PATH
+
+# Restore previous directory
+cd "$CWD"
+
+# Register path symlink
+ln -s /usr/lib/1Password /opt/1Password
 
 # Then we install the 1password CLI binary as well
 
+cd "$(mktemp -d)"
 wget -q https://cache.agilebits.com/dist/1P/op2/pkg/v2.14.0/op_linux_amd64_v2.14.0.zip
-
 unzip op_linux_amd64_v2.14.0.zip
 
 mv op /usr/bin
 
-groupadd onepassword-cli
+groupadd -g ${GID_OPCLI} onepassword-cli
 chown root:onepassword-cli /usr/bin/op
 chmod g+s /usr/bin/op
 

--- a/scripts/1password.sh
+++ b/scripts/1password.sh
@@ -4,49 +4,82 @@ set -e
 
 echo "Installing 1Password"
 
-mkdir /var/opt # temporary storage, will not end up in ostree
-rpm-ostree install https://downloads.1password.com/linux/rpm/stable/x86_64/1password-latest.rpm
+# On libostree systems, /opt is a symlink to /var/opt,
+# which actually only exists on the live system. /var is
+# a separate mutable, stateful FS that's overlaid onto
+# the ostree rootfs. Therefore we need to install it into
+# /usr/lib/1Password instead, and dynamically create a
+# symbolic link /opt/1Password => /usr/lib/1Password upon
+# boot.
 
-mv /var/opt/1Password /usr/lib/1Password # move installed 1password to non-volatile /usr/lib
+ONEPASSWORD_RPM='https://downloads.1password.com/linux/rpm/stable/x86_64/1password-latest.rpm'
 
-#create symlink /usr/bin/1password pointing to /opt/1Password/1password
+# Prepare staging directory
+mkdir -p /var/opt # -p just in case it exists
+# for some reason...
+
+# Now let's install the package.
+rpm-ostree install "${ONEPASSWORD_RPM}"
+
+# And then we do the hacky dance!
+mv /var/opt/1Password /usr/lib/1Password # move this over here
+
+# Create a symlink /usr/bin/1password => /opt/1Password/1password
 rm /usr/bin/1password
 ln -s /opt/1Password/1password /usr/bin/1password
 
-# hacked from 1password-latest.tar.gz//after-install.sh
+#####
+# The following is a bastardization of "after-install.sh"
+# which is normally packaged with 1password. You can compare with
+# /usr/lib/1Password/after-install.sh if you want to see.
 
 cd /usr/lib/1Password
+
 # chrome-sandbox requires the setuid bit to be specifically set.
 # See https://github.com/electron/electron/issues/17972
 chmod 4755 /usr/lib/1Password/chrome-sandbox
 
-GROUP_NAME="onepassword"
-GID_OP="1500"
-GID_OPCLI="1600"
+# Normally, after-install.sh would create a group,
+# "onepassword", right about now. But if we do that during
+# the ostree build it'll disappear from the running system!
+# I'm going to work around that by hardcoding GIDs and
+# crossing my fingers that nothing else steps on them.
+# These numbers _should_ be okay under normal use, but
+# if there's a more specific range that I should use here
+# please submit a PR!
 
-# Setup the Core App Integration helper binary with the correct permissions and group
-# if [ ! "$(getent group "${GROUP_NAME}")" ]; then
-#   # GID must be > 1000, and I'd prefer GID > highest user GID
-#   groupadd -K GID_MIN=1500 "${GROUP_NAME}"
-# fi
+# Specifically, GID must be > 1000, and absolutely must not
+# conflict with any real groups on the deployed system.
+# Normal user group GIDs on Fedora are sequential starting
+# at 1000, so let's skip ahead and set to something higher.
+GID_ONEPASSWORD="1500"
+GID_ONEPASSWORDCLI="1600"
 
 HELPER_PATH="/usr/lib/1Password/1Password-KeyringHelper"
 BROWSER_SUPPORT_PATH="/usr/lib/1Password/1Password-BrowserSupport"
 
-chgrp -R "${GID_OP}" /usr/lib/1Password
+# Setup the Core App Integration helper binaries with the correct permissions and group
+chgrp "${GID_ONEPASSWORD}" "${HELPER_PATH}"
 # The binary requires setuid so it may interact with the Kernel keyring facilities
-chmod u+s $HELPER_PATH
-chmod g+s $HELPER_PATH
+chmod u+s "${HELPER_PATH}"
+chmod g+s "${HELPER_PATH}"
 
-# This gives no extra permissions to the binary. It only hardens it against environmental tampering.
-chgrp "${GID_OP}" $BROWSER_SUPPORT_PATH
-chmod g+s $BROWSER_SUPPORT_PATH
+# BrowserSupport binary needs setgid. This gives no extra permissions to the binary.
+# It only hardens it against environmental tampering.
+chgrp "${GID_ONEPASSWORD}" "${BROWSER_SUPPORT_PATH}"
+chmod g+s "${BROWSER_SUPPORT_PATH}"
 
-# Restore previous directory
-cd "$CWD"
+# Dynamically create the required group via sysusers.d
+# and set the GID based on the files we just chgrp'd
+cat >/usr/lib/sysusers.d/onepassword.conf <<EOF
+g     onepassword ${HELPER_PATH}
+EOF
 
 # Register path symlink
-ln -s /usr/lib/1Password /opt/1Password
+# We do this via tmpfiles.d so that it is created by the live system.
+cat >/usr/lib/tmpfiles.d/onepassword.conf <<EOF
+L  /opt/1Password  -  -  -  -  /usr/lib/1Password
+EOF
 
 # Then we install the 1password CLI binary as well
 
@@ -56,8 +89,15 @@ unzip op_linux_amd64_v2.14.0.zip
 
 mv op /usr/bin
 
-groupadd -g ${GID_OPCLI} onepassword-cli
-chown root:onepassword-cli /usr/bin/op
+# it needs its own group and needs setgid, like the other helpers.
+#groupadd -g ${GID_ONEPASSWORDCLI} onepassword-cli
+chown root:${GID_ONEPASSWORDCLI} /usr/bin/op
 chmod g+s /usr/bin/op
+
+# Dynamically create the required group via sysusers.d
+# and set the GID based on the files we just chgrp'd
+cat >/usr/lib/sysusers.d/onepassword.conf <<EOF
+g     onepassword-cli /usr/bin/op
+EOF
 
 op --version


### PR DESCRIPTION
Marked this as a draft, because it still needs a couple changes on the overlay that I'm not sure how to do while building. Namely the ownership (group especially)

Plus 1Password creates custom utility groups, but their GID must be > 1000 _and_ must not conflict with the user's GID.

You need to `sudo groupadd -g 1500 onepassword && sudo groupadd -g 1600 onepassword-cli` from the booted system for integration to work right. This can be added to a custom justfile or made into a simple script. Or maybe systemd-sysusers or whatnot can create the groups?